### PR TITLE
feat: modify get license page to be plan agnostic

### DIFF
--- a/apps/ui/src/components/license-key/GetLicenseView.tsx
+++ b/apps/ui/src/components/license-key/GetLicenseView.tsx
@@ -25,6 +25,7 @@ interface GetLicenseViewProps {
 export function GetLicenseView({ token }: GetLicenseViewProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const [licenseKey, setLicenseKey] = useState("")
+  const [planDisplayName, setPlanDisplayName] = useState("")
   const [error, setError] = useState<string | null>(
     token ? null : "ERR_TOKEN_NOT_FOUND"
   )
@@ -47,6 +48,7 @@ export function GetLicenseView({ token }: GetLicenseViewProps) {
       }
 
       setLicenseKey(result.license)
+      setPlanDisplayName(result.planDisplayName ?? "")
     } catch (fetchError) {
       console.error("Error while fetching license key:", fetchError)
       setError("DEFAULT")
@@ -86,10 +88,12 @@ export function GetLicenseView({ token }: GetLicenseViewProps) {
     <div className="flex flex-col gap-8 py-8">
       <div>
         <Typography tag="h1" variant="header2" className="mb-4">
-          Thank you for choosing the Strapi Growth Plan!
+          License access
         </Typography>
         <Typography tag="p" variant="subtitle1" textColor="muted">
-          Please find your license below.
+          {planDisplayName
+            ? `Your ${planDisplayName} license is ready.`
+            : "Your Strapi license is ready."}
         </Typography>
       </div>
 


### PR DESCRIPTION
### Task Link
Resolves https://linear.app/strapi/issue/EE-109/website-update-for-a-plan-agnostic-license-delivery-page

### Description


- License access page will be used for non-Growth plans too
- We make the page generic enough in regard to the displayed plan
