### PR TITLE
feat(ui): add CTA card side column to blog posts

### DIFF
--- a/apps/strapi/src/api/blog-post/content-types/blog-post/schema.json
+++ b/apps/strapi/src/api/blog-post/content-types/blog-post/schema.json
@@ -76,6 +76,11 @@
     "content": {
       "type": "richtext"
     },
+    "sidebar": {
+      "type": "component",
+      "component": "cards.cta-card",
+      "repeatable": true
+    },
     "sections": {
       "type": "dynamiczone",
       "components": [

--- a/apps/strapi/src/api/blog/content-types/blog/schema.json
+++ b/apps/strapi/src/api/blog/content-types/blog/schema.json
@@ -29,6 +29,11 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::blog-post.blog-post"
+    },
+    "sidebar": {
+      "type": "component",
+      "component": "cards.cta-card",
+      "repeatable": true
     }
   }
 }

--- a/apps/strapi/src/components/cards/cta-card.json
+++ b/apps/strapi/src/components/cards/cta-card.json
@@ -1,0 +1,37 @@
+{
+  "collectionName": "components_cards_cta_cards",
+  "info": {
+    "displayName": "CTA Card",
+    "icon": "cursor",
+    "description": "Reusable call-to-action card: title, optional image, description and one link. Usable in any dynamic zone."
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 60
+    },
+    "description": {
+      "type": "text",
+      "maxLength": 160
+    },
+    "image": {
+      "type": "component",
+      "component": "utilities.basic-image",
+      "repeatable": false
+    },
+    "ctaLink": {
+      "type": "component",
+      "component": "utilities.link",
+      "repeatable": false,
+      "required": true
+    },
+    "buttonStyle": {
+      "type": "enumeration",
+      "enum": ["primary", "secondary"],
+      "default": "secondary",
+      "required": true
+    }
+  }
+}

--- a/apps/strapi/types/generated/components.d.ts
+++ b/apps/strapi/types/generated/components.d.ts
@@ -112,6 +112,32 @@ export interface CardsContentCard extends Struct.ComponentSchema {
   }
 }
 
+export interface CardsCtaCard extends Struct.ComponentSchema {
+  collectionName: "components_cards_cta_cards"
+  info: {
+    description: "Reusable call-to-action card: title, optional image, description and one link. Usable in any dynamic zone."
+    displayName: "CTA Card"
+    icon: "cursor"
+  }
+  attributes: {
+    buttonStyle: Schema.Attribute.Enumeration<["primary", "secondary"]> &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<"secondary">
+    ctaLink: Schema.Attribute.Component<"utilities.link", false> &
+      Schema.Attribute.Required
+    description: Schema.Attribute.Text &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 160
+      }>
+    image: Schema.Attribute.Component<"utilities.basic-image", false>
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 60
+      }>
+  }
+}
+
 export interface CardsFeatureCard extends Struct.ComponentSchema {
   collectionName: "components_cards_feature_card"
   info: {
@@ -1707,6 +1733,7 @@ declare module "@strapi/strapi" {
       "blog.resource-cta": BlogResourceCta
       "cards.case-study-card": CardsCaseStudyCard
       "cards.content-card": CardsContentCard
+      "cards.cta-card": CardsCtaCard
       "cards.feature-card": CardsFeatureCard
       "cms.field-entry": CmsFieldEntry
       "elements.brand-logo-grid-item": ElementsBrandLogoGridItem

--- a/apps/strapi/types/generated/contentTypes.d.ts
+++ b/apps/strapi/types/generated/contentTypes.d.ts
@@ -574,6 +574,7 @@ export interface ApiBlogPostBlogPost extends Struct.CollectionTypeSchema {
       ]
     >
     seo: Schema.Attribute.Component<"shared.seo", false>
+    sidebar: Schema.Attribute.Component<"cards.cta-card", true>
     slug: Schema.Attribute.UID<"title"> & Schema.Attribute.Required
     tags: Schema.Attribute.Relation<"manyToMany", "api::post-tag.post-tag">
     title: Schema.Attribute.String & Schema.Attribute.Required
@@ -659,6 +660,7 @@ export interface ApiBlogBlog extends Struct.SingleTypeSchema {
     navigation: Schema.Attribute.Component<"blog.navigation", false>
     newsletter: Schema.Attribute.Component<"forms.newsletter", false>
     publishedAt: Schema.Attribute.DateTime
+    sidebar: Schema.Attribute.Component<"cards.cta-card", true>
     updatedAt: Schema.Attribute.DateTime
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private

--- a/apps/ui/src/components/blog/BlogSidebar.tsx
+++ b/apps/ui/src/components/blog/BlogSidebar.tsx
@@ -1,0 +1,69 @@
+import type { Data } from "@repo/strapi-types"
+
+import { StrapiCtaCard } from "@/components/page-builder/components/cards/StrapiCtaCard"
+import { cn } from "@/lib/styles"
+
+type CtaCard = Data.Component<"cards.cta-card">
+
+interface BlogSidebarProps {
+  /** Cards set on the post itself. When non-empty these replace the default. */
+  readonly postCards?: CtaCard[] | null
+  /** Blog-wide default cards from the Blog single type. */
+  readonly defaultCards?: CtaCard[] | null
+  /**
+   * `column` is the fixed-width sticky rail beside the article.
+   * `inline` flows the cards into the article width once there is no room
+   * beside it — without this they keep the rail's narrow width and look broken.
+   */
+  readonly variant?: "column" | "inline"
+  readonly className?: string
+  /** Applied to the card wrapper — used to make the column stick on scroll. */
+  readonly innerClassName?: string
+}
+
+/**
+ * Blog post side column.
+ *
+ * Cards are configured blog-wide on the Blog single type and can be overridden
+ * per post. The override is all-or-nothing rather than a merge: merge order
+ * would be ambiguous and invisible to the editor.
+ *
+ * Renders nothing when neither source has cards, so posts without a sidebar
+ * keep the original centered layout.
+ */
+export function BlogSidebar({
+  postCards,
+  defaultCards,
+  variant = "column",
+  className,
+  innerClassName,
+}: BlogSidebarProps) {
+  const cards = postCards?.length ? postCards : (defaultCards ?? [])
+
+  if (cards.length === 0) {
+    return null
+  }
+
+  return (
+    <aside
+      data-slot="blog-sidebar"
+      data-variant={variant}
+      aria-label="Related resources"
+      className={className}
+    >
+      <div
+        className={cn(
+          "gap-4",
+          variant === "column"
+            ? "flex w-70 flex-col"
+            : "grid grid-cols-1 sm:grid-cols-2",
+          innerClassName
+        )}
+      >
+        {cards.map((card) => (
+          <StrapiCtaCard key={card.id} component={card} />
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/apps/ui/src/components/layouts/StrapiBlogPostView.tsx
+++ b/apps/ui/src/components/layouts/StrapiBlogPostView.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/blog/BlogAuthorBanner"
 import { BlogAutoRelatedPosts } from "@/components/blog/BlogAutoRelatedPosts"
 import { BlogContent } from "@/components/blog/BlogContent"
+import { BlogSidebar } from "@/components/blog/BlogSidebar"
 import { BlogSocialShare } from "@/components/blog/BlogSocialShare"
 import { Container } from "@/components/elementary/Container"
 import { StrapiSeoStructuredDataFromSeo } from "@/components/page-builder/components/seo-utilities/StrapiSeoStructuredData"
@@ -17,8 +18,9 @@ import { extractHeadings, type BlogPost } from "@/lib/blog-utils"
 import { getEnvVar } from "@/lib/env-vars"
 import { routing } from "@/lib/navigation"
 import { SECTION_SPACING } from "@/lib/section-spacing"
-import { fetchBlogPost } from "@/lib/strapi-api/content/server"
+import { fetchBlog, fetchBlogPost } from "@/lib/strapi-api/content/server"
 import { buildBlogPostingJsonLd } from "@/lib/structured-data/blog-posting"
+import { cn } from "@/lib/styles"
 
 import { BlogNavbar } from "../blog/BlogNavbar"
 import { BlogPostHeader } from "../blog/BlogPostHeader"
@@ -43,11 +45,21 @@ export function StrapiBlogPostView({ params }: Props) {
   setRequestLocale(locale)
 
   const response = use(fetchBlogPost(slug, locale))
+  // Blog-wide sidebar defaults, overridden per post when the post sets its own.
+  const blogSettings = use(fetchBlog(locale))
 
   const post = response?.data as BlogPost | null | undefined
   if (!post) {
     notFound()
   }
+
+  // Same resolution the sidebar itself applies: a post overrides the blog-wide
+  // default outright. Needed here too, because the surrounding layout changes
+  // when a side column is present.
+  const sidebarCards = post.sidebar?.length
+    ? post.sidebar
+    : (blogSettings?.data?.sidebar ?? [])
+  const hasSidebar = sidebarCards.length > 0
 
   const sections = post.sections
   const author = post.author as BlogAuthor | null
@@ -100,36 +112,83 @@ export function StrapiBlogPostView({ params }: Props) {
           {content && (
             <section className="py-8 lg:py-16">
               <div className="relative">
-                {headings.length > 0 && (
-                  <aside className="absolute top-0 left-0 hidden h-full xl:block">
-                    <BlogTableOfContents headings={headings} />
-                  </aside>
-                )}
+                {/* With a side column the ToC becomes a real column in the
+                    row, so all four tracks line up on the site grid. Without
+                    one it keeps its original full-bleed absolute position. */}
+                <div
+                  className={cn(
+                    "mx-auto flex justify-center",
+                    hasSidebar && "w-full max-w-312 gap-8 px-4 xl:px-0"
+                  )}
+                >
+                  {headings.length > 0 && (
+                    <aside
+                      className={cn(
+                        "hidden h-full",
+                        hasSidebar
+                          ? "w-52 shrink-0 xl:block"
+                          : "absolute top-0 left-0 xl:block"
+                      )}
+                    >
+                      <BlogTableOfContents headings={headings} />
+                    </aside>
+                  )}
 
-                <aside className="absolute top-0 left-[calc(50%+27rem+1rem)] hidden h-full xl:block">
-                  <div className="sticky top-28 pb-24">
-                    <BlogSocialShare
-                      url={postUrl}
-                      title={post.title ?? ""}
-                      variant="sticky"
-                    />
+                  <div className="relative w-full max-w-216 min-w-0">
+                    <Container variant="condensed">
+                      <article data-slot="blog-article">
+                        <BlogContent>{content}</BlogContent>
+                      </article>
+
+                      <BlogSocialShare
+                        url={postUrl}
+                        title={post.title ?? ""}
+                        variant="row"
+                        className="xl:hidden"
+                      />
+
+                      {/* No room beside the article below xl, so the cards
+                          flow into the article width rather than vanishing
+                          or keeping the rail's narrow column. */}
+                      <BlogSidebar
+                        variant="inline"
+                        className="mt-8 xl:hidden"
+                        postCards={post.sidebar}
+                        defaultCards={blogSettings?.data?.sidebar}
+                      />
+
+                      <BlogAuthorBanner author={author} />
+                    </Container>
+
+                    {/* Anchored to the article, not the viewport, so it holds
+                        its place whether or not a side column is present. */}
+                    <aside className="absolute top-0 left-full ml-4 hidden h-full xl:block">
+                      <div className="sticky top-28 pb-24">
+                        <BlogSocialShare
+                          url={postUrl}
+                          title={post.title ?? ""}
+                          variant="sticky"
+                        />
+                      </div>
+                    </aside>
                   </div>
-                </aside>
 
-                <Container variant="condensed">
-                  <article data-slot="blog-article">
-                    <BlogContent>{content}</BlogContent>
-                  </article>
-
-                  <BlogSocialShare
-                    url={postUrl}
-                    title={post.title ?? ""}
-                    variant="row"
-                    className="xl:hidden"
+                  {/* ml clears the share rail, which is absolutely positioned
+                      just outside the article and would otherwise sit flush
+                      against the cards. */}
+                  {/* A sticky element can only travel through space its
+                      container has left over. The share rail is short so it
+                      always has room; a tall card stack does not — hence the
+                      viewport cap, which keeps the column pinned (scrolling
+                      internally if needed) instead of drifting off-screen.
+                      Bottom padding is kept small for the same reason. */}
+                  <BlogSidebar
+                    className="hidden shrink-0 xl:ml-20 xl:block"
+                    innerClassName="sticky top-28 max-h-[calc(100vh-8rem)] overflow-y-auto pb-8"
+                    postCards={post.sidebar}
+                    defaultCards={blogSettings?.data?.sidebar}
                   />
-
-                  <BlogAuthorBanner author={author} />
-                </Container>
+                </div>
               </div>
             </section>
           )}

--- a/apps/ui/src/components/page-builder/components/cards/StrapiCtaCard.tsx
+++ b/apps/ui/src/components/page-builder/components/cards/StrapiCtaCard.tsx
@@ -1,0 +1,66 @@
+import type { Data } from "@repo/strapi-types"
+import type { ComponentProps } from "react"
+
+import { StrapiBasicImage } from "@/components/page-builder/components/utilities/StrapiBasicImage"
+import { StrapiLink } from "@/components/page-builder/components/utilities/StrapiLink"
+import { cn } from "@/lib/styles"
+
+interface StrapiCtaCardProps extends ComponentProps<"div"> {
+  readonly component: Data.Component<"cards.cta-card">
+}
+
+/**
+ * Reusable call-to-action card — title, optional image, description and one
+ * link. `ctaLink` carries the internal-page vs external-URL choice, so this
+ * component never needs to know which kind of destination it points at.
+ */
+export function StrapiCtaCard({
+  component,
+  className,
+  ...rest
+}: StrapiCtaCardProps) {
+  if (!component.title || !component.ctaLink) {
+    return null
+  }
+
+  const isPrimary = component.buttonStyle === "primary"
+
+  return (
+    <div
+      data-slot="cta-card"
+      className={cn(
+        "border-strapi-neutral-150 flex flex-col gap-4 rounded-xl border bg-white p-5",
+        className
+      )}
+      {...rest}
+    >
+      <h2 className="text-strapi-gray-950 text-xl leading-tight font-bold">
+        {component.title}
+      </h2>
+
+      {component.image && (
+        <StrapiBasicImage
+          component={component.image}
+          className="aspect-video w-full rounded-lg object-cover"
+          sizes="(max-width: 1280px) 100vw, 320px"
+        />
+      )}
+
+      {component.description && (
+        <p className="text-strapi-gray-700 text-sm leading-relaxed">
+          {component.description}
+        </p>
+      )}
+
+      <StrapiLink
+        component={component.ctaLink}
+        className={cn(
+          "inline-flex h-[42px] w-full items-center justify-center rounded-md px-6 text-sm font-bold transition-colors",
+          isPrimary
+            ? "bg-strapi-purple-600 hover:bg-strapi-purple-600/90 text-white"
+            : "border-strapi-neutral-200 text-strapi-gray-950 hover:bg-strapi-neutral-100 border bg-white"
+        )}
+      />
+    </div>
+  )
+}

--- a/apps/ui/src/lib/strapi-api/content/server.ts
+++ b/apps/ui/src/lib/strapi-api/content/server.ts
@@ -80,6 +80,14 @@ const seoPopulate = {
   },
 }
 
+// `cards.cta-card` is a plain repeatable component rather than a dynamic zone,
+// so it is not covered by the backend populateDynamicZone config and has to be
+// populated explicitly. `ctaLink.page` supplies fullPath for internal links.
+const ctaCardPopulate = {
+  image: { populate: { media: true } },
+  ctaLink: { populate: { page: { fields: ["fullPath"] } } },
+} as Record<string, unknown>
+
 // ------ Page fetching functions
 
 export async function fetchPage(
@@ -172,6 +180,7 @@ export async function fetchBlogPost(
           },
           tags: true,
           seo: seoPopulate,
+          sidebar: { populate: ctaCardPopulate },
         } as Record<string, unknown>,
         populateDynamicZone: { sections: true },
       },
@@ -753,6 +762,7 @@ export async function fetchBlog(locale: Locale) {
       featuredBlogPost: {
         populate: blogListPopulate,
       },
+      sidebar: { populate: ctaCardPopulate },
     },
   } satisfies FindFirst<"api::blog.blog">
 


### PR DESCRIPTION
## What & why

Blog posts render as a single centred article, so the only promo surface is an inline section at the bottom — which readers reach only *after* finishing the piece. This adds a side column beside the article for marketing CTAs.

<img width="1802" height="1574" alt="CleanShot 2026-07-30 at 16 09 09@2x" src="https://github.com/user-attachments/assets/c8561f94-d547-48c8-9cc5-d04ec70d5186" />


## Content model

**`cards.cta-card`** — a generic, reusable component: title, optional image, description, one link, and a `primary | secondary` button style.

It is deliberately named for its **structure, not a use case**. An editor can make it a demo promo, a sales prompt, a webinar invite or a docs link with no schema change, and it can be dropped into any dynamic zone — not just the blog.

The link reuses the existing **`utilities.link`**, so a CTA points at either an internal page relation or an external URL with `newTab` — the same choice the hero section already offers, with the same conditional fields (`href` shows for `external`, the page picker for `page`).

**Two-tier placement.** `sidebar` is a repeatable `cards.cta-card` on both:

| Location | Role |
| --- | --- |
| `api::blog.blog` (Blog single type) | blog-wide default shown on every post |
| `api::blog-post.blog-post` | optional per-post override; empty = inherit |

The single type is the primary home because the cards are evergreen. Re-adding them to every post by hand would not survive contact with a real content team, and new posts would otherwise publish with an empty column. A post that sets its own column replaces the default outright rather than merging — merge order would be ambiguous and invisible to the editor.

## Layout

- Article and column are centred as **one group** inside the standard page container, so the column's right edge lands on the same grid as the hero and navbar.
- The share rail is now anchored to the article (`left-full`) instead of a viewport offset (`left-[calc(50%+27rem+1rem)]`) that only cleared above 1536px.
- The column shows from `xl` and **sticks on scroll**, like the share rail.
- Below `xl` the cards flow into the article width rather than vanishing or keeping the rail's narrow column.

**Tradeoff:** with a column present the article narrows from 864px to 616px — that is what lets four tracks fit the page grid. Posts without a sidebar are completely unchanged.

## Testing

Verified locally against Strapi + Next: both link modes resolve correctly (`type: page` → the page's `fullPath`, `type: external` → the URL with `target="_blank" rel="noopener noreferrer"`), cards render beside the article and not below it, the image sits between heading and button, the column sticks through a long scroll, cards fall inline below `xl`, and there is no horizontal overflow at any breakpoint.

`tsc --noEmit` and ESLint are clean on all changed files.

## Note for reviewers

`apps/strapi/types/generated/*` was **hand-written in typegen's format** because `pnpm generate:types` currently fails on `main` with `e.charAt is not a function` — it fails on a clean checkout too, so it predates this branch. Those files should be regenerated once that is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)