### PR TITLE
fix: allow growth checkout tunnel with additional seats

### DIFF
--- a/apps/ui/src/components/page-builder/components/plans/strapi-plan-pricing-cards/usePricingCheckoutModalState.ts
+++ b/apps/ui/src/components/page-builder/components/plans/strapi-plan-pricing-cards/usePricingCheckoutModalState.ts
@@ -186,17 +186,14 @@ export function buildCheckoutUrl({
     }
   }
 
+  const planItemPriceId =
+    selectedSsoItemPriceId?.trim() || selectedPlanItemPriceId
+
   const subscriptionItems: { itemPriceId: string; quantity?: number }[] = [
     {
-      itemPriceId: selectedPlanItemPriceId,
+      itemPriceId: planItemPriceId,
     },
   ]
-
-  if (selectedSsoItemPriceId?.trim()) {
-    subscriptionItems.push({
-      itemPriceId: selectedSsoItemPriceId,
-    })
-  }
 
   if (additionalSeatItemPriceId && additionalSeats > 0) {
     subscriptionItems.push({


### PR DESCRIPTION
### Description

We have a pretty critical fix: we can't purchase a SSO Growth plan with additional seats:

1. Go on https://strapi.io/pricing-cms
2. Click on Growth `Buy now`
3. Turn on SSO
4. Increase the number of Seats
5. Click on `Continue`
6. You are redirected to a non-working page:

<img width="505" height="128" alt="image" src="https://github.com/user-attachments/assets/3b1284f8-8ce0-4ea2-8270-639d689ecd75" />

This is because in the redirected URL: `https://strapi.chargebee.com/hosted_pages/checkout?layout=full_page&subscription_items[item_price_id][0]=growth-v2-USD-Monthly&subscription_items[item_price_id][1]=growth-sso-v2-USD-Monthly&subscription_items[item_price_id][2]=additional-seat-USD-Monthly&subscription_items[quantity][2]=2`

There is an extra parameter: `subscription_items[item_price_id][0]=growth-v2-USD-Monthly` should not be there!
