### PR TITLE
85 blog post intro with prefetch fix

### DIFF
--- a/apps/strapi/prettier.config.mjs
+++ b/apps/strapi/prettier.config.mjs
@@ -1,0 +1,12 @@
+import { prettierOptions } from "@repo/eslint-config/configs"
+
+/**
+ * Prettier configuration for Strapi must exclude the Tailwind plugin,
+ * otherwise generating types fails.
+ */
+export default {
+  ...prettierOptions,
+  plugins: prettierOptions.plugins.filter(
+    (p) => !String(p).includes("prettier-plugin-tailwindcss")
+  ),
+}

--- a/apps/strapi/src/api/blog-post/content-types/blog-post/schema.json
+++ b/apps/strapi/src/api/blog-post/content-types/blog-post/schema.json
@@ -73,6 +73,13 @@
     "originalPublishedAt": {
       "type": "datetime"
     },
+    "intro": {
+      "type": "dynamiczone",
+      "components": [
+        "sections.disclaimer",
+        "sections.richtext"
+      ]
+    },
     "content": {
       "type": "richtext"
     },

--- a/apps/strapi/src/documentMiddlewares/helpers.ts
+++ b/apps/strapi/src/documentMiddlewares/helpers.ts
@@ -142,6 +142,7 @@ export const getComponentsToPopulate = async (
     action: string
     documentId: string | number
     locale?: string
+    params?: Record<string, unknown>
   }
 ): Promise<Record<string, string[]>> => {
   const prefetchPopulate = buildDynamicZonePrefetchPopulate(
@@ -150,13 +151,18 @@ export const getComponentsToPopulate = async (
     dynamicZonePopulate
   )
 
+  // Pass filters/status/pagination from the real request so we don't
+  // prefetch the whole collection on every blog-post page.
   const prefetchedData = await strapi
     .documents(context.uid)
     [context.action].call(this, {
       documentId: context.documentId,
       populate: prefetchPopulate,
       fields: ["documentId"],
-      locale: context.locale,
+      locale: context.params?.locale ?? context.locale,
+      filters: context.params?.filters,
+      status: context.params?.status,
+      pagination: context.params?.pagination,
     })
 
   const entries = Array.isArray(prefetchedData)

--- a/apps/strapi/types/generated/contentTypes.d.ts
+++ b/apps/strapi/types/generated/contentTypes.d.ts
@@ -525,6 +525,9 @@ export interface ApiBlogPostBlogPost extends Struct.CollectionTypeSchema {
       Schema.Attribute.Private
     description: Schema.Attribute.Text
     image: Schema.Attribute.Component<"media.image", false>
+    intro: Schema.Attribute.DynamicZone<
+      ["sections.disclaimer", "sections.richtext"]
+    >
     level: Schema.Attribute.Enumeration<
       ["beginner", "intermediate", "advanced"]
     >
@@ -2186,6 +2189,7 @@ export interface PluginUsersPermissionsUser
     description: Schema.Attribute.Text
     email: Schema.Attribute.Email &
       Schema.Attribute.Required &
+      Schema.Attribute.Private &
       Schema.Attribute.SetMinMaxLength<{
         minLength: 6
       }>

--- a/apps/ui/src/components/layouts/StrapiBlogPostView.tsx
+++ b/apps/ui/src/components/layouts/StrapiBlogPostView.tsx
@@ -63,6 +63,7 @@ export function StrapiBlogPostView({ params }: Props) {
 
   const sections = post.sections
   const author = post.author as BlogAuthor | null
+  const intro = post.intro
   const content = post.content
   const headings = content ? extractHeadings(content) : []
   const hasManualRelated = (sections ?? []).some(
@@ -109,6 +110,17 @@ export function StrapiBlogPostView({ params }: Props) {
 
       <div className="flex w-full flex-col">
         <main className="flex w-full flex-col">
+          {intro && intro.length > 0 && (
+            <div className="pt-8 lg:pt-16">
+              <DynamicZoneRenderer
+                content={intro}
+                itemClassName="mb-8 md:mb-12 lg:mb-16 last:mb-0"
+                surface="page"
+                extraProps={{ currentSlug: slug, locale }}
+              />
+            </div>
+          )}
+
           {content && (
             <section className="py-8 lg:py-16">
               <div className="relative">

--- a/apps/ui/src/lib/strapi-api/content/server.ts
+++ b/apps/ui/src/lib/strapi-api/content/server.ts
@@ -182,7 +182,7 @@ export async function fetchBlogPost(
           seo: seoPopulate,
           sidebar: { populate: ctaCardPopulate },
         } as Record<string, unknown>,
-        populateDynamicZone: { sections: true },
+        populateDynamicZone: { intro: true, sections: true },
       },
       withCacheTags(dm.isEnabled, STRAPI_TAGS.blogPost, requestInit),
       options


### PR DESCRIPTION
### Task Link
[Task #](https://github.com/strapi/website/issues/85)

### Description
- Restores blog post `intro` dynamic zone (re-apply of #85 after revert)
- Fixes `populateDynamicZone` prefetch so it reuses request filters/status/pagination (was scanning ~all blog posts per request and breaking SSG)

### Checklist - author

- [x] **Assignee** is set (the active developer of this PR).
- [ ] **Reviewers** are set (team members who will review the code).
- [ ] **PR is linked** I have linked the PR to an issue in Jira.
- [x] **Description** I have described the changes proposed in the PR clearly and concisely (more important than what is why).
- [ ] **Screenshots/Videos** I have added screenshots/videos or they were not needed.
- [ ] **Environmental variables** are listed or they were not needed.
- [ ] **Unit/Integration tests** are added for all utilities and business important logic
- [ ] **Labels** I have added labels to the PR.
  - Use `requires-env-vars` when PR requires environmental variables
  - Use `ready-for-review` when PR is ready to be looked at
  - Use `ready-to-merge` when PR has a passing review
  - Use `needs-revisions` when PR has comments that block merge
  - Use `do-not-review` when PR is daft only and you don't want to get a review
- [ ] [OPTIONAL] Conversation/documentation is started in places where the code is not self-explanatory

#### Before merging

- [ ] **PR is approved**
- [ ] **All conversations are resolved**
- [ ] Pipelines are not failing 

### Checklist - reviewer

- [ ] I **understand** all proposed changes.
- [ ] Necessary **after deploy steps** are handled by someone (adding new env var, syncing config, running migration...)

