### PR TITLE
fix: typing animation stuck on revive

### DIFF
--- a/apps/ui/src/components/ui/typing-animation.tsx
+++ b/apps/ui/src/components/ui/typing-animation.tsx
@@ -20,6 +20,9 @@ interface Char {
 
 type Phase = "waiting" | "typing" | "deleting"
 
+/** Must exceed `--animate-char-fade-out` (110ms). */
+const EXIT_DURATION_MS = 250
+
 interface TypingAnimationProps extends ComponentProps<"span"> {
   words: string[]
   typeSpeed?: number
@@ -120,66 +123,39 @@ export function TypingAnimation({
     }
 
     const interval = setInterval(() => {
-      setChars((prev) => {
-        const idx = findLastNonExiting(prev)
-        if (idx < 0) {
-          return prev
-        }
-
-        return prev.map((c, i) => (i === idx ? { ...c, exiting: true } : c))
-      })
+      setChars(markLastCharExiting)
     }, deleteSpeed)
 
     return () => clearInterval(interval)
   }, [deleteSpeed, hasWords, phase, prefersReducedMotion])
 
-  // Remove character from DOM when its exit animation finishes
-  const handleAnimationEnd = useCallback(
-    (key: number) => {
-      setChars((prev) => {
-        const nextChars = prev.filter((c) => c.key !== key)
-
-        if (hasWords && phase === "deleting" && nextChars.length === 0) {
-          queueMicrotask(() => {
-            setWordIndex((index) => (index + 1) % words.length)
-            setPhase("typing")
-          })
-        }
-
-        return nextChars
-      })
-    },
-    [hasWords, phase, words.length]
-  )
-
-  // Force-clear stuck exiting chars when tab regains visibility
-  // (browsers pause CSS animations in hidden tabs, so animationend may never fire)
+  // Advance once delete is done. Driven by a timer so a missed animationend
+  // (e.g. background tab) cannot leave an empty word + blinking cursor.
   useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined
-
-    const onVisibilityChange = () => {
-      if (document.visibilityState !== "visible") {
-        return
-      }
-
-      // Give browser a moment to fire pending animationend events
-      timeoutId = setTimeout(() => {
-        setChars((prev) => {
-          if (prev.length > 0 && prev.every((c) => c.exiting)) {
-            return []
-          }
-
-          return prev
-        })
-      }, 200)
+    if (!hasWords || prefersReducedMotion || phase !== "deleting") {
+      return
     }
 
-    document.addEventListener("visibilitychange", onVisibilityChange)
-
-    return () => {
-      document.removeEventListener("visibilitychange", onVisibilityChange)
-      clearTimeout(timeoutId)
+    // Wait until every character has started exiting (or none left)
+    if (chars.length > 0 && !chars.every((c) => c.exiting)) {
+      return
     }
+
+    const timeout = setTimeout(
+      () => {
+        setChars([])
+        setWordIndex((index) => (index + 1) % words.length)
+        setPhase("typing")
+      },
+      chars.length === 0 ? 0 : EXIT_DURATION_MS
+    )
+
+    return () => clearTimeout(timeout)
+  }, [chars, hasWords, phase, prefersReducedMotion, words.length])
+
+  // Visual only — state machine advances from the delete-finished effect above
+  const handleAnimationEnd = useCallback((key: number) => {
+    setChars((prev) => prev.filter((c) => c.key !== key))
   }, [])
 
   if (words.length === 0) {
@@ -230,6 +206,15 @@ function findLastNonExiting(chars: Char[]): number {
   }
 
   return -1
+}
+
+function markLastCharExiting(chars: Char[]): Char[] {
+  const idx = findLastNonExiting(chars)
+  if (idx < 0) {
+    return chars
+  }
+
+  return chars.map((c, i) => (i === idx ? { ...c, exiting: true } : c))
 }
 
 const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)"


### PR DESCRIPTION
### Task Link
[Task #83](https://github.com/strapi/website/issues/83)

### Description
Fix hero typing animation getting stuck on a blinking cursor when CSS animationend doesn’t fire (e.g. after a backgrounded Chrome tab).
Advance to the next word on a timer once delete finishes, instead of relying on animationend for phase/word changes.

### Checklist - author

- [x] **Assignee** is set (the active developer of this PR).
- [ ] **Reviewers** are set (team members who will review the code).
- [x] **PR is linked** I have linked the PR to an issue in Jira.
- [x] **Description** I have described the changes proposed in the PR clearly and concisely (more important than what is why).
- [ ] **Screenshots/Videos** I have added screenshots/videos or they were not needed.
- [ ] **Environmental variables** are listed or they were not needed.
- [ ] **Unit/Integration tests** are added for all utilities and business important logic
- [ ] **Labels** I have added labels to the PR.
  - Use `requires-env-vars` when PR requires environmental variables
  - Use `ready-for-review` when PR is ready to be looked at
  - Use `ready-to-merge` when PR has a passing review
  - Use `needs-revisions` when PR has comments that block merge
  - Use `do-not-review` when PR is daft only and you don't want to get a review
- [ ] [OPTIONAL] Conversation/documentation is started in places where the code is not self-explanatory

#### Before merging

- [ ] **PR is approved**
- [ ] **All conversations are resolved**
- [ ] Pipelines are not failing 

### Checklist - reviewer

- [ ] I **understand** all proposed changes.
- [ ] Necessary **after deploy steps** are handled by someone (adding new env var, syncing config, running migration...)

