### PR TITLE
feat: add first touch script fo /contact-sales only

### DIFF
--- a/apps/ui/src/components/layouts/StrapiPageView.tsx
+++ b/apps/ui/src/components/layouts/StrapiPageView.tsx
@@ -10,6 +10,7 @@ import { MinimalHeader } from "@/components/layouts/MinimalHeader"
 import { StrapiSeoStructuredDataFromSeo } from "@/components/page-builder/components/seo-utilities/StrapiSeoStructuredData"
 import { StrapiStructuredData } from "@/components/page-builder/components/seo-utilities/StrapiStructuredData"
 import { DynamicZoneRenderer } from "@/components/page-builder/DynamicZoneRenderer"
+import { FirstTouchScript } from "@/components/providers/TrackingScripts"
 import { getEnvVar } from "@/lib/env-vars"
 import { createPublicFullPath } from "@/lib/navigation"
 import { SECTION_SPACING } from "@/lib/section-spacing"
@@ -74,6 +75,7 @@ export function StrapiPageView({ params, searchParams }: Props) {
 
   return (
     <div className="flex w-full flex-col">
+      {data.fullPath === "/contact-sales" && <FirstTouchScript />}
       {minimalLayout && <div data-minimal-layout hidden />}
       {minimalLayout && <MinimalHeader />}
       <StrapiSeoStructuredDataFromSeo seo={data?.seo} />

--- a/apps/ui/src/components/providers/TrackingScripts.tsx
+++ b/apps/ui/src/components/providers/TrackingScripts.tsx
@@ -33,6 +33,27 @@ export function TrackingScriptWrapper({
   )
 }
 
+/**
+ * First Touch visitor tracking — contact-sales page only.
+ */
+export function FirstTouchScript() {
+  if (!isProduction()) {
+    return null
+  }
+
+  return (
+    <Script id="first-touch-loader" strategy="afterInteractive">
+      {`(function() {
+          var el = document.createElement('script');
+          el.id = 'first-touch-script';
+          el.src = 'https://app.firsttouch.ai/first-touch-web-visitors.js?id=FnSDSSTRoP0kUnJxtFolacgwZsMGdvYI&customer_id=2469c089-4669-4998-adce-a83c337d7ae5';
+          el.async = true;
+          document.head.appendChild(el);
+        })();`}
+    </Script>
+  )
+}
+
 export function TrackingScripts() {
   if (!isProduction()) {
     return null


### PR DESCRIPTION
### Task Link
Task #88 

### Description
Load the First Touch visitor script on the contact-sales page only (production), so sales attribution can be tracked there.

### Checklist - author

- [x] **Assignee** is set (the active developer of this PR).
- [ ] **Reviewers** are set (team members who will review the code).
- [x] **PR is linked** I have linked the PR to an issue in Jira.
- [x] **Description** I have described the changes proposed in the PR clearly and concisely (more important than what is why).
- [ ] **Screenshots/Videos** I have added screenshots/videos or they were not needed.
- [ ] **Environmental variables** are listed or they were not needed.
- [ ] **Unit/Integration tests** are added for all utilities and business important logic
- [ ] **Labels** I have added labels to the PR.
  - Use `requires-env-vars` when PR requires environmental variables
  - Use `ready-for-review` when PR is ready to be looked at
  - Use `ready-to-merge` when PR has a passing review
  - Use `needs-revisions` when PR has comments that block merge
  - Use `do-not-review` when PR is daft only and you don't want to get a review
- [ ] [OPTIONAL] Conversation/documentation is started in places where the code is not self-explanatory

#### Before merging

- [ ] **PR is approved**
- [ ] **All conversations are resolved**
- [ ] Pipelines are not failing 

### Checklist - reviewer

- [ ] I **understand** all proposed changes.
- [ ] Necessary **after deploy steps** are handled by someone (adding new env var, syncing config, running migration...)

