### PR TITLE
feat: add Github URL to navbar single type

### DIFF
--- a/apps/strapi/src/components/navigation/navbar.json
+++ b/apps/strapi/src/components/navigation/navbar.json
@@ -34,6 +34,20 @@
     "githubStars": {
       "type": "boolean",
       "default": true
+    },
+    "githubUrl": {
+      "type": "string",
+      "default": "https://github.com/strapi/strapi",
+      "conditions": {
+        "visible": {
+          "==": [
+            {
+              "var": "githubStars"
+            },
+            true
+          ]
+        }
+      }
     }
   }
 }

--- a/apps/strapi/types/generated/components.d.ts
+++ b/apps/strapi/types/generated/components.d.ts
@@ -791,6 +791,8 @@ export interface NavigationNavbar extends Struct.ComponentSchema {
     bottomLinks: Schema.Attribute.Component<"utilities.link", true>
     ctaLinks: Schema.Attribute.Component<"utilities.link", true>
     githubStars: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<true>
+    githubUrl: Schema.Attribute.String &
+      Schema.Attribute.DefaultTo<"https://github.com/strapi/strapi">
     logoImage: Schema.Attribute.Component<"utilities.link-image", false>
     logoImageLight: Schema.Attribute.Component<"utilities.link-image", false>
     navItems: Schema.Attribute.Component<"navbar.nav-item", true>

--- a/apps/ui/src/components/elementary/GithubStarButton.tsx
+++ b/apps/ui/src/components/elementary/GithubStarButton.tsx
@@ -6,10 +6,12 @@ function formatStars(count: number): string {
 }
 
 interface GithubStarButtonProps extends React.ComponentProps<"a"> {
+  readonly href: string
   readonly stars: number | null
 }
 
 export function GithubStarButton({
+  href,
   stars,
   className,
   ...restProps
@@ -20,7 +22,7 @@ export function GithubStarButton({
 
   return (
     <a
-      href="https://github.com/strapi/strapi"
+      href={href}
       target="_blank"
       rel="noreferrer"
       className={cn(

--- a/apps/ui/src/components/page-builder/components/navigation/navbar/DesktopNavbar.tsx
+++ b/apps/ui/src/components/page-builder/components/navigation/navbar/DesktopNavbar.tsx
@@ -23,6 +23,7 @@ interface DesktopNavbarProps extends React.ComponentProps<"div"> {
   readonly logoImage: Nullable<Data.Component<"utilities.link-image">>
   readonly logoImageLight: Nullable<Data.Component<"utilities.link-image">>
   readonly githubStars: number | null
+  readonly githubUrl: Nullable<string>
   readonly className?: string
 }
 
@@ -36,6 +37,7 @@ export function DesktopNavbar({
   logoImage,
   logoImageLight,
   githubStars,
+  githubUrl,
   className,
   ...restProps
 }: DesktopNavbarProps) {
@@ -93,7 +95,13 @@ export function DesktopNavbar({
 
       <div className="ml-auto flex items-center gap-2">
         <GlobalSearch />
-        <GithubStarButton stars={githubStars} className="hidden xl:flex" />
+        {githubUrl ? (
+          <GithubStarButton
+            href={githubUrl}
+            stars={githubStars}
+            className="hidden xl:flex"
+          />
+        ) : null}
         {ctaLinks?.map((link, index) => (
           <StrapiLink
             key={link.id ?? index}

--- a/apps/ui/src/components/page-builder/components/navigation/navbar/StrapiNavbar.tsx
+++ b/apps/ui/src/components/page-builder/components/navigation/navbar/StrapiNavbar.tsx
@@ -12,7 +12,11 @@ export async function StrapiNavbar({
 }: {
   readonly component: Data.Component<"navigation.navbar">
 }) {
-  const githubStars = component.githubStars ? await fetchGithubStars() : null
+  const githubUrl = component.githubUrl
+  const githubStars =
+    component.githubStars && githubUrl
+      ? await fetchGithubStars(githubUrl)
+      : null
 
   return (
     <nav
@@ -40,6 +44,7 @@ export async function StrapiNavbar({
           logoImage={component.logoImage}
           logoImageLight={component.logoImageLight}
           githubStars={githubStars}
+          githubUrl={githubUrl}
         />
 
         <MobileNavbar

--- a/apps/ui/src/lib/github.ts
+++ b/apps/ui/src/lib/github.ts
@@ -2,13 +2,38 @@ export interface GithubRepoResponse {
   stargazers_count: number
 }
 
+function parseGithubRepoPath(repoUrl: string): string | null {
+  try {
+    const url = new URL(repoUrl)
+    if (url.hostname !== "github.com" && url.hostname !== "www.github.com") {
+      return null
+    }
+
+    const [owner, repo] = url.pathname.split("/").filter(Boolean)
+    if (!owner || !repo) {
+      return null
+    }
+
+    return `${owner}/${repo}`
+  } catch {
+    return null
+  }
+}
+
 /**
- * Fetch the number of stars for the Strapi repository from GitHub.
+ * Fetch the number of stars for a GitHub repository.
  * The request is cached for 3 hours.
  */
-export async function fetchGithubStars(): Promise<number | null> {
+export async function fetchGithubStars(
+  repoUrl: string
+): Promise<number | null> {
+  const repoPath = parseGithubRepoPath(repoUrl)
+  if (repoPath == null) {
+    return null
+  }
+
   try {
-    const response = await fetch("https://api.github.com/repos/strapi/strapi", {
+    const response = await fetch(`https://api.github.com/repos/${repoPath}`, {
       next: { revalidate: 10800 },
       headers: { Accept: "application/vnd.github.v3+json" },
     })

--- a/packages/migration/src/config/entities.ts
+++ b/packages/migration/src/config/entities.ts
@@ -2401,6 +2401,7 @@ export const ENTITY_CONFIGS: Record<string, EntityMigrationConfig> = {
               bottomLinks,
               ctaLinks,
               githubStars: true,
+              githubUrl: "https://github.com/strapi/strapi",
             },
           ],
         }


### PR DESCRIPTION
### Task Link
#75 

### Description
- Make the GitHub star button URL CMS-configurable instead of hardcoded.
- Add `githubUrl` on the `Navbar` component (next to `githubStars`), default `https://github.com/strapi/strapi`, visible only when stars are enabled.
- Use that URL for both the button href and the GitHub stars API lookup.

### Checklist - author

- [x] **Assignee** is set (the active developer of this PR).
- [ ] **Reviewers** are set (team members who will review the code).
- [x] **PR is linked** I have linked the PR to an issue in Jira.
- [x] **Description** I have described the changes proposed in the PR clearly and concisely (more important than what is why).
- [ ] **Screenshots/Videos** I have added screenshots/videos or they were not needed.
- [ ] **Environmental variables** are listed or they were not needed.
- [ ] **Unit/Integration tests** are added for all utilities and business important logic
- [ ] **Labels** I have added labels to the PR.
  - Use `requires-env-vars` when PR requires environmental variables
  - Use `ready-for-review` when PR is ready to be looked at
  - Use `ready-to-merge` when PR has a passing review
  - Use `needs-revisions` when PR has comments that block merge
  - Use `do-not-review` when PR is daft only and you don't want to get a review
- [ ] [OPTIONAL] Conversation/documentation is started in places where the code is not self-explanatory

#### Before merging

- [ ] **PR is approved**
- [ ] **All conversations are resolved**
- [ ] Pipelines are not failing 

### Checklist - reviewer

- [ ] I **understand** all proposed changes.
- [ ] Necessary **after deploy steps** are handled by someone (adding new env var, syncing config, running migration...)

