### PR TITLE
fix: strapi hero image width and add blurred background

### DIFF
--- a/apps/ui/src/components/page-builder/components/sections/StrapiHero.tsx
+++ b/apps/ui/src/components/page-builder/components/sections/StrapiHero.tsx
@@ -61,11 +61,18 @@ export function StrapiHero({ component, renderContext }: StrapiHeroProps) {
             </div>
 
             {component.image ? (
-              <div className="animate-border-reveal animate-reveal-cascade border-strapi-gray-700/50 flex shrink-0 grow basis-1/2 items-center justify-center overflow-hidden max-md:border-t">
+              <div className="animate-border-reveal animate-reveal-cascade border-strapi-gray-700/50 relative flex shrink-0 grow basis-1/2 items-center justify-center overflow-hidden max-md:border-t">
+                <StrapiBasicImage
+                  component={component.image}
+                  decorative
+                  mode="fill"
+                  className="pointer-events-none inset-0 scale-150 object-cover opacity-70 blur-xl"
+                  sizes="(max-width: 768px) 100vw, 3200px"
+                />
                 <StrapiBasicImage
                   component={component.image}
                   mode="responsive"
-                  className="max-w-[640px]"
+                  className="relative z-10"
                   sizes="(max-width: 768px) 100vw, 640px"
                   priority={affectsNavbarTheme}
                 />


### PR DESCRIPTION
### Task Link
#100 

### Description
Constrain Strapi hero image width so it stretches to 100% of parent width.
Stack a decorative blurred copy behind the sharp image to fill leftover space.

### Checklist - author

- [x] **Assignee** is set (the active developer of this PR).
- [ ] **Reviewers** are set (team members who will review the code).
- [x] **PR is linked** I have linked the PR to an issue in Jira.
- [x] **Description** I have described the changes proposed in the PR clearly and concisely (more important than what is why).
- [ ] **Screenshots/Videos** I have added screenshots/videos or they were not needed.
- [ ] **Environmental variables** are listed or they were not needed.
- [ ] **Unit/Integration tests** are added for all utilities and business important logic
- [ ] **Labels** I have added labels to the PR.
  - Use `requires-env-vars` when PR requires environmental variables
  - Use `ready-for-review` when PR is ready to be looked at
  - Use `ready-to-merge` when PR has a passing review
  - Use `needs-revisions` when PR has comments that block merge
  - Use `do-not-review` when PR is daft only and you don't want to get a review
- [ ] [OPTIONAL] Conversation/documentation is started in places where the code is not self-explanatory

#### Before merging

- [ ] **PR is approved**
- [ ] **All conversations are resolved**
- [ ] Pipelines are not failing 

### Checklist - reviewer

- [ ] I **understand** all proposed changes.
- [ ] Necessary **after deploy steps** are handled by someone (adding new env var, syncing config, running migration...)

